### PR TITLE
Add listeners for 'change', 'remove' and 'reset' only once

### DIFF
--- a/backbone.grouped-collection.js
+++ b/backbone.grouped-collection.js
@@ -51,6 +51,9 @@
 
     Lib._onReset(options);
     options.group_collection.listenTo(options.collection, 'add', _.partial(Lib._onAdd, options));
+    options.group_collection.listenTo(options.collection, 'change', _.partial(Lib._onAdd, options));
+    options.group_collection.listenTo(options.collection, 'remove', _.partial(Lib._onRemove, options));
+    options.group_collection.listenTo(options.collection, 'reset', _.partial(Lib._onReset, options));
 
     return options.group_collection;
   };
@@ -72,10 +75,6 @@
     group = new Constructor({id: group_id, vc: vc});
     group.vc = vc;
     vc.listenTo(vc, 'remove', _.partial(Lib._onVcRemove, options.group_collection, group));
-
-    options.group_collection.listenTo(options.collection, 'change', _.partial(Lib._onAdd, options));
-    options.group_collection.listenTo(options.collection, 'remove', _.partial(Lib._onRemove, options));
-    options.group_collection.listenTo(options.collection, 'reset', _.partial(Lib._onReset, options));
 
     return group;
   };


### PR DESCRIPTION
The listeners on `group_collection` to the 'change', 'remove' and 'reset' events on the collection are added each time a group is created. Adding it only once is enough.

Secondly, if a `VirtualCollection` is created with an empty collection, no group is created and no listeners are added. With this fix the empty virtual collection is also updated when a 'change', 'remove' or 'reset' event is triggered.
