### PR TITLE
TypeError: Backbone.VirtualCollection is not a constructor

### DIFF
--- a/backbone.grouped-collection.js
+++ b/backbone.grouped-collection.js
@@ -9,6 +9,8 @@
     _ = require('underscore');
     Backbone = require('backbone');
   }
+  
+  require('Backbone.VirtualCollection')
 
   /**
    * Checks a parameter from the obj


### PR DESCRIPTION
As far as I can see, VirtualCollection is never actually `require`d in backbone.grouped-collection.js
so I added a call to require VirtualCollection, so that it can be used.