### PR TITLE
adds `allGroup` option to API to add an optional group containing all…

### DIFF
--- a/backbone.grouped-collection.js
+++ b/backbone.grouped-collection.js
@@ -85,12 +85,11 @@
         vc, group, vc_options;
 
     vc_options = _.extend(options.vc_options || {}, {
-      filter: function (model) {
+      filter: options.groupBy !== undefined ? function (model) {
         return options.groupBy(model) === group_id;
-      },
+      } : undefined,
       close_with: options.close_with
-    });
-
+    });    
     vc = new Backbone.VirtualCollection(options.collection, vc_options);
     group = new Constructor({id: group_id, vc: vc});
     group.vc = vc;
@@ -133,9 +132,13 @@
    *
    * @param {Object} options
    */
-  Lib._onReset = function (options) {
+  Lib._onReset = function (options) {    
     var group_ids = _.uniq(options.collection.map(options.groupBy));
-    options.group_collection.reset(_.map(group_ids, _.partial(Lib._createGroup, options)));
+    var group_models = _.map(group_ids, _.partial(Lib._createGroup, options));
+    if(options.allGroup){
+      group_models.push(Lib._createGroup(_.omit(options, 'groupBy'), options.allGroup.id || 'all'));
+    }
+    options.group_collection.reset(group_models);    
   };
 
   /**

--- a/test/backbone.grouped-collection_spec.js
+++ b/test/backbone.grouped-collection_spec.js
@@ -102,6 +102,32 @@ describe('Backbone.GroupedCollection', function () {
       assert.equal(gc.get('Panthers').vc.length, 1);
     });
 
+    it('accepts allGroup option and groups models according to the groupBy function', function () {
+      var gc = Backbone.buildGroupedCollection({        
+        collection: collection,
+        groupBy: byClub,
+        allGroup: true
+      });
+      assert.deepEqual(gc.pluck('id').sort(), ['all', 'Penguins', 'Panthers'].sort());
+      assert.equal(gc.get('all').vc.length, 3);
+      assert.equal(gc.get('Penguins').vc.length, 2);
+      assert.equal(gc.get('Panthers').vc.length, 1);
+    });
+
+    it('accepts allGroup option with id and groups models according to the groupBy function', function () {
+      var gc = Backbone.buildGroupedCollection({        
+        collection: collection,
+        groupBy: byClub,
+        allGroup: {
+          id: "hello"
+        }
+      });
+      assert.deepEqual(gc.pluck('id').sort(), ['hello', 'Penguins', 'Panthers'].sort());
+      assert.equal(gc.get('hello').vc.length, 3);
+      assert.equal(gc.get('Penguins').vc.length, 2);
+      assert.equal(gc.get('Panthers').vc.length, 1);
+    });
+
     it('accepts a comparator function', function () {
       var gc = Backbone.buildGroupedCollection({
         collection: collection,


### PR DESCRIPTION
adds `allGroup` option to API to add an optional group containing all models.

`options.allGroup` can be a boolean `true` value which will auto id the all group with `id: 'all'` or it can be an object ie. `{id:'Everything I Own'}` to specify the id
